### PR TITLE
[fixed] ModalPortal's componentWillReceiveProps

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -45,12 +45,10 @@ var ModalPortal = module.exports = React.createClass({
     // Focus only needs to be set once when the modal is being opened
     if (!this.props.isOpen && newProps.isOpen) {
       this.setFocusAfterRender(true);
-    }
-
-    if (newProps.isOpen === true)
       this.open();
-    else if (newProps.isOpen === false)
+    } else if (this.props.isOpen && !newProps.isOpen) {
       this.close();
+    }
   },
 
   componentDidUpdate: function () {


### PR DESCRIPTION
For some reason componentWillReceiveProps is being called with identical props. We need to compare previous props with new props to make sure state is changing from closed to open before calling this.open(). Otherwise we're calling this.open() even when state isn't changing. Same with this.close().