### PR TITLE
Use classnames instead of react/lib/cx

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -2,7 +2,7 @@ var React = require('react');
 var div = React.DOM.div;
 var focusManager = require('../helpers/focusManager');
 var scopeTab = require('../helpers/scopeTab');
-var cx = require('react/lib/cx');
+var cx = require('classnames');
 
 // so that our CSS is statically analyzable
 var CLASS_NAMES = {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.12.0",
+    "classnames": "^1.2.0"
   },
-  "dependencies": {},
   "tags": [
     "react",
     "modal",


### PR DESCRIPTION
classSet / cx will be removed in a future version of React. 

This also removes the following warning when running the test suite:

    WARN: 'Warning: React.addons.classSet will be deprecated in a future version. See http://fb.me/react-addons-classset'

See also:
https://github.com/facebook/react/commit/b6980ab9809fc3ddc68c20129618f0414d49b2a4
https://www.npmjs.com/package/classnames