### PR TITLE
Check if modalElement exists in handleFocus.

### DIFF
--- a/lib/helpers/focusManager.js
+++ b/lib/helpers/focusManager.js
@@ -10,6 +10,9 @@ function handleBlur(event) {
 function handleFocus(event) {
   if (needToFocus) {
     needToFocus = false;
+    if (!modalElement) {
+      return;
+    }
     // need to see how jQuery shims document.on('focusin') so we don't need the
     // setTimeout, firefox doesn't support focusin, if it did, we could focus
     // the the element outisde of a setTimeout. Side-effect of this


### PR DESCRIPTION
A race condition happens if you open a new window before closing the modal, as opening a new window has the side effect of blurring the current window.