### PR TITLE
Allow component to render without DOM libs

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -15,7 +15,7 @@ var Modal = module.exports = React.createClass({
   propTypes: {
     isOpen: React.PropTypes.bool.isRequired,
     onRequestClose: React.PropTypes.func,
-    appElement: React.PropTypes.instanceOf(HTMLElement),
+    appElement: React.PropTypes.instanceOf(typeof HTMLElement === 'undefined' ? {} : HTMLElement),
     closeTimeoutMS: React.PropTypes.number,
     ariaHideApp: React.PropTypes.bool
   },


### PR DESCRIPTION
This is just a quick hack that enables the component to not throw when being rendered on the server