### PR TITLE
[fixed] Allow version 2.x of classnames dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "react": ">=0.12.0",
-    "classnames": "^1.2.0"
+    "classnames": "1.2 – 2"
   },
   "tags": [
     "react",


### PR DESCRIPTION
The api has not changed only some rare edge cases which are not used here.

Without the change this library can't be used with classnames 2.x