### PR TITLE
[fixed] 'unknow runtime error' in IE8

### DIFF
--- a/lib/helpers/injectCSS.js
+++ b/lib/helpers/injectCSS.js
@@ -34,9 +34,15 @@ function injectStyle(css) {
   if (!style) {
     style = document.createElement('style');
     style.setAttribute('id', 'rackt-style');
-    var head = document.getElementsByTagName('head')[0];
-    head.insertBefore(style, head.firstChild);
+    style.setAttribute("type", "text/css");
   }
-  style.innerHTML = style.innerHTML+'\n'+css;
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+    document.body.appendChild(style);
+  } else {
+    style.innerHTML = css;
+    document.head.appendChild(style);
+  }
 }
 


### PR DESCRIPTION
Got `unknown runtime error` when `innerHTML` run on IE8, so I added conditional statement to set style by `cssText` when running on IE8 .