### PR TITLE
Moves classnames to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "uglify-js": "2.4.15",
     "webpack-dev-server": "1.6.5"
   },
-  "peerDependencies": {
-    "react": ">=0.12.0",
+  "dependencies": {
     "classnames": "^1.2.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.12.0"
   },
   "tags": [
     "react",


### PR DESCRIPTION
This makes it a bit more compatible with the way peerDependencies will work in `npm@3` later down the line.
It also makes it so that consumers of the lib can have another version of classnames at the app level while
not requiring this particular lib to require a version bump.  Plus, this lib sorta depends on it and should
it need to be locked down to a particular version, this lib should manage that rather than expect it to
happen at the app level.