### PR TITLE
[fixed] Clear the closeWithTimeout timer before unmounting

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -43,6 +43,10 @@ var ModalPortal = module.exports = React.createClass({
     }
   },
 
+  componentWillUnmount: function() {
+    clearTimeout(this.closeTimer);
+  },
+
   componentWillReceiveProps: function(newProps) {
     // Focus only needs to be set once when the modal is being opened
     if (!this.props.isOpen && newProps.isOpen) {
@@ -87,7 +91,7 @@ var ModalPortal = module.exports = React.createClass({
 
   closeWithTimeout: function() {
     this.setState({beforeClose: true}, function() {
-      setTimeout(this.closeWithoutTimeout, this.props.closeTimeoutMS);
+      this.closeTimer = setTimeout(this.closeWithoutTimeout, this.props.closeTimeoutMS);
     }.bind(this));
   },
 


### PR DESCRIPTION
If you try to close a modal, then unmount it from the render tree before it's done with its close animation, the `closeWithoutTimeout` call still fires, which causes a harmless JS error about settings state on an unmounted component.  Canceling the `closeWithoutTimeout` call avoids this error.