### PR TITLE
Support for reactjs 0.14

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
+var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
 var elementClass = require('element-class');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "browserify-shim": "3.8.10",
     "envify": "3.4.0",
     "expect": "1.10.0",
+    "fbjs": "^0.3.1",
     "jsx-loader": "0.13.2",
     "karma": "0.13.10",
     "karma-browserify": "^4.2.1",


### PR DESCRIPTION
It seems that ExecutionEnvironment has been removed from reactjs. I added the fbjs package. This package contains the code for ExecutionEnvironment.