### PR TITLE
Use renderSubtreeIntoContainer to keep context.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -4,6 +4,7 @@ var ExecutionEnvironment = require('exenv');
 var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
 var elementClass = require('element-class');
+var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeIntoContainer;
 
 var SafeHTMLElement = ExecutionEnvironment.canUseDOM ? window.HTMLElement : {};
 
@@ -66,7 +67,7 @@ var Modal = module.exports = React.createClass({
       ariaAppHider.toggle(props.isOpen, props.appElement);
     }
     sanitizeProps(props);
-    this.portal = ReactDOM.render(ModalPortal(props), this.node);
+    this.portal = renderSubtreeIntoContainer(this, ModalPortal(props), this.node);
   },
 
   render: function () {


### PR DESCRIPTION
In 0.14, this is required so that the modal children of access to the context.