### PR TITLE
Fix build for 0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dialog"
   ],
   "browserify-shim": {
-    "react": "global:React"
+    "react": "global:React",
+    "react-dom": "global:ReactDOM"
   }
 }


### PR DESCRIPTION
Ignore ReactDOM in browserify-shim config, so it not gets included in final build.